### PR TITLE
feat(worker): added global `exec_on_success` and `exec_on_failure` op…

### DIFF
--- a/worker/config.go
+++ b/worker/config.go
@@ -47,6 +47,9 @@ type globalConfig struct {
 	MirrorDir  string `toml:"mirror_dir"`
 	Concurrent int    `toml:"concurrent"`
 	Interval   int    `toml:"interval"`
+
+	ExecOnSuccess []string `toml:"exec_on_success"`
+	ExecOnFailure []string `toml:"exec_on_failure"`
 }
 
 type managerConfig struct {
@@ -87,8 +90,13 @@ type mirrorConfig struct {
 	Env       map[string]string `toml:"env"`
 	Role      string            `toml:"role"`
 
-	ExecOnSuccess string `toml:"exec_on_success"`
-	ExecOnFailure string `toml:"exec_on_failure"`
+	// These two options over-write the global options
+	ExecOnSuccess []string `toml:"exec_on_success"`
+	ExecOnFailure []string `toml:"exec_on_failure"`
+
+	// These two options  the global options
+	ExecOnSuccessExtra []string `toml:"exec_on_success_extra"`
+	ExecOnFailureExtra []string `toml:"exec_on_failure_extra"`
 
 	Command       string `toml:"command"`
 	UseIPv6       bool   `toml:"use_ipv6"`

--- a/worker/config_test.go
+++ b/worker/config_test.go
@@ -36,7 +36,9 @@ provider = "command"
 upstream = "https://aosp.google.com/"
 interval = 720
 mirror_dir = "/data/git/AOSP"
-exec_on_success = "bash -c 'echo ${TUNASYNC_JOB_EXIT_STATUS} > ${TUNASYNC_WORKING_DIR}/exit_status'"
+exec_on_success = [
+	"bash -c 'echo ${TUNASYNC_JOB_EXIT_STATUS} > ${TUNASYNC_WORKING_DIR}/exit_status'"
+]
 	[mirrors.env]
 	REPO = "/usr/local/bin/aosp-repo"
 
@@ -53,7 +55,9 @@ provider = "rsync"
 upstream = "rsync://ftp.fedoraproject.org/fedora/"
 use_ipv6 = true
 exclude_file = "/etc/tunasync.d/fedora-exclude.txt"
-exec_on_failure = "bash -c 'echo ${TUNASYNC_JOB_EXIT_STATUS} > ${TUNASYNC_WORKING_DIR}/exit_status'"
+exec_on_failure = [
+	"bash -c 'echo ${TUNASYNC_JOB_EXIT_STATUS} > ${TUNASYNC_WORKING_DIR}/exit_status'"
+]
 	`
 
 	Convey("When giving invalid file", t, func() {


### PR DESCRIPTION
…tions

if `exec_on_success` is set on mirror-level config, it overrides the global option; if on mirror

level, extra hook cmd is needed, use `exec_on_success_extra` option