### PR TITLE
 worker rsync 方式增加 --include-from 选项 ,worker配置文件增加 include_file 参数即可

### DIFF
--- a/worker/config.go
+++ b/worker/config.go
@@ -124,6 +124,7 @@ type mirrorConfig struct {
 	Command       string `toml:"command"`
 	UseIPv6       bool   `toml:"use_ipv6"`
 	UseIPv4       bool   `toml:"use_ipv4"`
+	IncludeFile   string `toml:"include_file"`
 	ExcludeFile   string `toml:"exclude_file"`
 	Username      string `toml:"username"`
 	Password      string `toml:"password"`

--- a/worker/provider.go
+++ b/worker/provider.go
@@ -126,6 +126,7 @@ func newMirrorProvider(mirror mirrorConfig, cfg *Config) mirrorProvider {
 			username:    mirror.Username,
 			password:    mirror.Password,
 			excludeFile: mirror.ExcludeFile,
+			includeFile: mirror.IncludeFile,
 			workingDir:  mirrorDir,
 			logDir:      logDir,
 			logFile:     filepath.Join(logDir, "latest.log"),

--- a/worker/rsync_provider.go
+++ b/worker/rsync_provider.go
@@ -9,7 +9,7 @@ import (
 type rsyncConfig struct {
 	name                                         string
 	rsyncCmd                                     string
-	upstreamURL, username, password, excludeFile string
+	upstreamURL, username, password, excludeFile,includeFile string
 	workingDir, logDir, logFile                  string
 	useIPv6, useIPv4                             bool
 	interval                                     time.Duration
@@ -41,8 +41,8 @@ func newRsyncProvider(c rsyncConfig) (*rsyncProvider, error) {
 	}
 
 	options := []string{
-		"-aHvh", "--no-o", "--no-g", "--stats",
-		"--exclude", ".~tmp~/",
+		"-aHvh", "--no-o", "--no-g", "--stats", "-n",
+		"--exclude", ".~tmp~/","--include",
 		"--delete", "--delete-after", "--delay-updates",
 		"--safe-links", "--timeout=120", "--contimeout=120",
 	}
@@ -51,6 +51,10 @@ func newRsyncProvider(c rsyncConfig) (*rsyncProvider, error) {
 		options = append(options, "-6")
 	} else if c.useIPv4 {
 		options = append(options, "-4")
+	}
+
+	if c.includeFile !="" {
+		options =  append(options, "--include-from", c.includeFile)
 	}
 
 	if c.excludeFile != "" {

--- a/worker/rsync_provider.go
+++ b/worker/rsync_provider.go
@@ -41,7 +41,7 @@ func newRsyncProvider(c rsyncConfig) (*rsyncProvider, error) {
 	}
 
 	options := []string{
-		"-aHvh", "--no-o", "--no-g", "--stats", "-n",
+		"-aHvh", "--no-o", "--no-g", "--stats",
 		"--exclude", ".~tmp~/","--include",
 		"--delete", "--delete-after", "--delay-updates",
 		"--safe-links", "--timeout=120", "--contimeout=120",


### PR DESCRIPTION
worker.conf 示例:
```
[global]
name = "test_worker"
log_dir = "/tmp/tunasync/log/tunasync/{{.Name}}"
mirror_dir = "/data/tunasync"
concurrent = 10
interval = 1

[manager]
api_base = "http://localhost:14242"
token = "some_token"
ca_cert = ""

[cgroup]
enable = false
base_path = "/sys/fs/cgroup"
group = "tunasync"

[server]
hostname = "localhost"
listen_addr = "127.0.0.1"
listen_port = 6000
ssl_cert = ""
ssl_key = ""

[[mirrors]]
name = "saltstack"
provider = "rsync"
options = "-n"
upstream = "rsync://mirrors.shu.edu.cn/saltstack/"
mirror_dir = "/data/tunasyc/saltstack-test"
include_file = "/etc/tunasync/salt_include.txt"
exclude_file = "/etc/tunasync/salt_exclude.txt"
use_ipv6 = false

```
