### PR TITLE
Use proper logging for some debug output

### DIFF
--- a/cmd/tunasynctl/tunasynctl.go
+++ b/cmd/tunasynctl/tunasynctl.go
@@ -55,6 +55,7 @@ type config struct {
 
 func loadConfig(cfgFile string, cfg *config) error {
 	if cfgFile != "" {
+		logger.Infof("Loading config: %s", cfgFile)
 		if _, err := toml.DecodeFile(cfgFile, cfg); err != nil {
 			logger.Errorf(err.Error())
 			return err
@@ -78,7 +79,6 @@ func initialize(c *cli.Context) error {
 	if _, err := os.Stat(systemCfgFile); err == nil {
 		loadConfig(systemCfgFile, cfg)
 	}
-	fmt.Println(os.ExpandEnv(userCfgFile))
 	if _, err := os.Stat(os.ExpandEnv(userCfgFile)); err == nil {
 		loadConfig(os.ExpandEnv(userCfgFile), cfg)
 	}
@@ -185,7 +185,7 @@ func listJobs(c *cli.Context) error {
 			fmt.Sprintf("Error printing out informations: %s", err.Error()),
 			1)
 	}
-	fmt.Printf(string(b))
+	fmt.Print(string(b))
 	return nil
 }
 

--- a/cmd/tunasynctl/tunasynctl.go
+++ b/cmd/tunasynctl/tunasynctl.go
@@ -135,7 +135,7 @@ func listWorkers(c *cli.Context) error {
 				err.Error()),
 			1)
 	}
-	fmt.Print(string(b))
+	fmt.Println(string(b))
 	return nil
 }
 
@@ -185,7 +185,7 @@ func listJobs(c *cli.Context) error {
 			fmt.Sprintf("Error printing out informations: %s", err.Error()),
 			1)
 	}
-	fmt.Print(string(b))
+	fmt.Println(string(b))
 	return nil
 }
 

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -24,9 +24,12 @@ func InitLogger(verbose, debug, withSystemd bool) {
 
 	if debug {
 		logging.SetLevel(logging.DEBUG, "tunasync")
+		logging.SetLevel(logging.DEBUG, "tunasynctl-cmd")
 	} else if verbose {
 		logging.SetLevel(logging.INFO, "tunasync")
+		logging.SetLevel(logging.INFO, "tunasynctl-cmd")
 	} else {
 		logging.SetLevel(logging.NOTICE, "tunasync")
+		logging.SetLevel(logging.NOTICE, "tunasynctl-cmd")
 	}
 }

--- a/worker/cmd_provider.go
+++ b/worker/cmd_provider.go
@@ -96,7 +96,7 @@ func (p *cmdProvider) Run() error {
 	}
 	if p.failOnMatch != nil {
 		matches, err := internal.FindAllSubmatchInFile(p.LogFile(), p.failOnMatch)
-		fmt.Printf("FindAllSubmatchInFile: %q\n", matches)
+		logger.Infof("FindAllSubmatchInFile: %q\n", matches)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This patch changes some `fmt.print` debug output usage in tunasynctl and cmd_provider to use proper loggers. Also the logger will now respect logging level in tunasynctl commands.

*Disclaimer: I am not a Go coder so please do double check the patch. Thanks for your amazing work!*