### PR TITLE
fix examlpe with docker_image

### DIFF
--- a/docs/zh_CN/workers.conf
+++ b/docs/zh_CN/workers.conf
@@ -7,6 +7,11 @@ mirror_dir = "/srv/tunasync"
 concurrent = 10
 interval = 1
 
+# ensure the exec user be add into `docker` group
+[docker]
+# in `command provider` can use docker_image and docker_volumes
+enable = true
+
 [manager]
 api_base = "http://localhost:12345"
 token = "some_token"


### PR DESCRIPTION
If `docker.enable` not be `true`, the worker will ignore docker provider's config, and just exec the command.
so we need to doc it.