### PR TITLE
add useIPv4 option to two stage rsync

### DIFF
--- a/worker/provider.go
+++ b/worker/provider.go
@@ -176,6 +176,7 @@ func newMirrorProvider(mirror mirrorConfig, cfg *Config) mirrorProvider {
 			logDir:            logDir,
 			logFile:           filepath.Join(logDir, "latest.log"),
 			useIPv6:           mirror.UseIPv6,
+			useIPv4:           mirror.UseIPv4,
 			interval:          time.Duration(mirror.Interval) * time.Minute,
 			retry:             mirror.Retry,
 			timeout:           time.Duration(mirror.Timeout) * time.Second,

--- a/worker/two_stage_rsync_provider.go
+++ b/worker/two_stage_rsync_provider.go
@@ -19,7 +19,7 @@ type twoStageRsyncConfig struct {
 	rsyncTimeoutValue                            int
 	rsyncEnv                                     map[string]string
 	workingDir, logDir, logFile                  string
-	useIPv6                                      bool
+	useIPv6, useIPv4                             bool
 	interval                                     time.Duration
 	retry                                        int
 	timeout                                      time.Duration
@@ -137,6 +137,8 @@ func (p *twoStageRsyncProvider) Options(stage int) ([]string, error) {
 
 	if p.useIPv6 {
 		options = append(options, "-6")
+	} else if p.useIPv4 {
+		options = append(options, "-4")
 	}
 
 	if p.excludeFile != "" {


### PR DESCRIPTION
We found that the "use_ipv4" option does not work for two-stage sync. And I am wondering if I can add it.