### PR TITLE
make go build use static-link mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-LDFLAGS="-X main.buildstamp=`date -u '+%s'` -X main.githash=`git rev-parse HEAD`"
+LDFLAGS="-X main.buildstamp=`date -u '+%s'` -X main.githash=`git rev-parse HEAD` -linkmode 'external' -extldflags '-static'"
 
 all: get tunasync tunasynctl
 


### PR DESCRIPTION
build dependences changed! 
e.g.
before:  `header-file.h` and `shared-library.so`, in centos glibc-devel
after: `header-file.h` and `archive-libraries.a`, in centos glibc-static